### PR TITLE
Fix key name conflict with Play SBT plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ data/out/
 
 credentials.sbt
 *credentials*
+
+# IntelliJ IDEA
+*.iml
+.idea
+.idea/
+.idea_*
+.idea/*
+**/.idea/*

--- a/Readme.md
+++ b/Readme.md
@@ -31,17 +31,17 @@ addSbtPlugin("ohnosequences" % "sbt-github-release" % "<version>")
 
 Most of these keys just reflect the [parameters from Github API](http://developer.github.com/v3/repos/releases/#create-a-release):
 
-Key           | Type        | Default value
--------------:|:------------|:--------------------------------------------------------
-`notesDir`    | `File`      | `notes/`
-`notesFile`   | `File`      | `<notesDir>/<version>.markdown`
-`repo`        | `String`    | `"<organization>/<normalizedName>"`
-`tag`         | `String`    | `"v<version>"`
-`releaseName` | `String`    | `"<name> <tag>"`
-`commitish`   | `String`    | `""` (the default repo's branch)
-`draft`       | `Boolean`   | `false`
-`prerelease`  | `Boolean`   | `false` (`true` if the version has a hyphen)
-`assets`      | `Seq[File]` | `Seq(<packageBin in Compile>)`
+Key             | Type        | Default value
+---------------:|:------------|:--------------------------------------------------------
+`notesDir`      | `File`      | `notes/`
+`notesFile`     | `File`      | `<notesDir>/<version>.markdown`
+`repo`          | `String`    | `"<organization>/<normalizedName>"`
+`tag`           | `String`    | `"v<version>"`
+`releaseName`   | `String`    | `"<name> <tag>"`
+`commitish`     | `String`    | `""` (the default repo's branch)
+`draft`         | `Boolean`   | `false`
+`prerelease`    | `Boolean`   | `false` (`true` if the version has a hyphen)
+`releaseAssets` | `Seq[File]` | `Seq(<packageBin in Compile>)`
 
 You can change them in your `build.sbt` for example
 

--- a/notes/0.2.2.markdown
+++ b/notes/0.2.2.markdown
@@ -1,0 +1,4 @@
+- Fixed key name conflict with Play plugin's.
+  ```
+  Some keys were defined with the same name but different types: 'assets' (sbt.Task[java.io.File], sbt.Task[scala.collection.Seq[java.io.File]])
+  ```

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -19,7 +19,7 @@ object SbtGithubReleasePlugin extends AutoPlugin {
       lazy val commitish = settingKey[String]("Specifies the commitish value that determines where the Git tag is created from")
       lazy val draft = settingKey[Boolean]("true to create a draft (unpublished) release, false to create a published one")
       lazy val prerelease = settingKey[Boolean]("true to identify the release as a prerelease. false to identify the release as a full release")
-      lazy val assets = taskKey[Seq[File]]("The files to upload")
+      lazy val releaseAssets = taskKey[Seq[File]]("The files to upload")
     }
 
     lazy val checkGithubCredentials = taskKey[GitHub]("Checks authentification and suggests to create a new oauth token if needed")
@@ -44,7 +44,7 @@ object SbtGithubReleasePlugin extends AutoPlugin {
     // a version containing a hyphen is a pre-release version 
     prerelease := version.value.matches(""".*-.*"""),
 
-    assets := Seq((packageBin in Compile).value),
+    releaseAssets := Seq((packageBin in Compile).value),
 
     checkGithubCredentials := {
       val log = streams.value.log
@@ -104,7 +104,7 @@ object SbtGithubReleasePlugin extends AutoPlugin {
         log.info(s"Github ${pre}release '${release.getName}' is ${pub} at\n  ${release.getHtmlUrl}")
       } else sys.error("Something went wrong with Github release")
 
-      assets.value foreach { asset =>
+      releaseAssets.value foreach { asset =>
         release.uploadAsset(asset, "application/zip")
         val rel = asset.relativeTo(baseDirectory.value).getOrElse(asset)
         log.info(s"Asset [${rel}] is uploaded to Github")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0-SNAPSHOT"
+version in ThisBuild := "0.2.2"


### PR DESCRIPTION
This closes #4 - Key name conflicts with Play SBT plugin.

I had deployed it to [my Bintray maven repo](https://bintray.com/kevinlee/maven/sbt-github-release/0.2.2/view#files) and tested it. It works fine.

I don't know why but maven style deployment didn't work well with SBT plugin so I had to do it in ivy style.
So when using it, it should be like

``` scala
resolvers += Resolver.url("bintray-kevinlee-maven", url("http://dl.bintray.com/kevinlee/maven"))(Resolver.ivyStylePatterns)

addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.2.2")
```

Anyway, this info is necessary for testing only (and I needed to use it as soon as possible).
