### PR TITLE
use task keys instead of setting keys

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.12

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -12,13 +12,13 @@ object SbtGithubReleasePlugin extends AutoPlugin {
     // this object is just as a namespace:
     object GithubRelease {
       lazy val notesDir = settingKey[File]("Directory with release notes")
-      lazy val notesFile = settingKey[File]("File with the release notes for the current version")
+      lazy val notesFile = taskKey[File]("File with the release notes for the current version")
       lazy val repo = settingKey[String]("org/repo")
-      lazy val tag = settingKey[String]("The name of the tag: vX.Y.Z")
-      lazy val releaseName = settingKey[String]("The name of the release")
+      lazy val tag = taskKey[String]("The name of the tag: vX.Y.Z")
+      lazy val releaseName = taskKey[String]("The name of the release")
       lazy val commitish = settingKey[String]("Specifies the commitish value that determines where the Git tag is created from")
       lazy val draft = settingKey[Boolean]("true to create a draft (unpublished) release, false to create a published one")
-      lazy val prerelease = settingKey[Boolean]("true to identify the release as a prerelease. false to identify the release as a full release")
+      lazy val prerelease = taskKey[Boolean]("true to identify the release as a prerelease. false to identify the release as a full release")
       lazy val releaseAssets = taskKey[Seq[File]]("The files to upload")
     }
 
@@ -40,8 +40,8 @@ object SbtGithubReleasePlugin extends AutoPlugin {
     releaseName := name.value +" "+ tag.value,
     commitish := "",
     draft := false,
-    // According to the Semantic Versioning Specification (rule 9) 
-    // a version containing a hyphen is a pre-release version 
+    // According to the Semantic Versioning Specification (rule 9)
+    // a version containing a hyphen is a pre-release version
     prerelease := version.value.matches(""".*-.*"""),
 
     releaseAssets := Seq((packageBin in Compile).value),
@@ -65,7 +65,7 @@ object SbtGithubReleasePlugin extends AutoPlugin {
           }
           case _ => sys.error("If you want to use sbt-github-release plugin, you should set credentials correctly")
         }
-      } 
+      }
       log.info("Github credentials are ok")
       GitHub.connect
     },


### PR DESCRIPTION
When using this plugin alongside sbt-release, `releaseOnGithub` holds on to the previous version, even after sbt-release has updated it. This seems to be cause by several keys here that are defined as settings, which are only evaluated once. After changing these to tasks and publishing locally, I was able to use the plugin in my `releaseProceess`:

```scala
releaseProcess := Seq[ReleaseStep](
  releaseStepTask(checkGithubCredentials),
  checkSnapshotDependencies,
  inquireVersions,
  runClean,
  runTest,
  setReleaseVersion,
  commitReleaseVersion,
  releaseStepTask(releaseOnGithub),
  tagRelease,
  publishArtifacts,
  setNextVersion,
  commitNextVersion,
  pushChanges
)
```