### PR TITLE
Parametrize release task with the version tag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ The main task is `githubRelease`, it creates the release and publishes the asses
 
 There are some other tasks which work as intermediate checks:
 
-* `ghreleaseCheckCredentials` — checks Github OAuth token and helps to set it if needed
+* `ghreleaseGetCredentials` — checks Github OAuth token and helps to set it if needed
 * `ghreleaseCheckRepo` — checks that the repository exists and is accessible
 * `ghreleaseCheckReleaseBuilder` — checks that Github repo contains the tag and there is no release based on it yet
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,4 +12,4 @@ libraryDependencies += "org.kohsuke" % "github-api" % "1.77"
 // libraryDependencies += "com.github.xuwei-k" %% "ghscala" % "0.2.14"
 wartremoverErrors in (Compile, compile) --= Seq(Wart.Any, Wart.NonUnitStatements)
 
-enablePlugins(SbtGithubReleasePlugin)
+// enablePlugins(SbtGithubReleasePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -11,3 +11,5 @@ libraryDependencies += "org.kohsuke" % "github-api" % "1.77"
 
 // libraryDependencies += "com.github.xuwei-k" %% "ghscala" % "0.2.14"
 wartremoverErrors in (Compile, compile) --= Seq(Wart.Any, Wart.NonUnitStatements)
+
+enablePlugins(SbtGithubReleasePlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-9-g5239d7c-SNAPSHOT")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2+")
 // addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-8-gc3118aa")
 
 // addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.1.2-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-8-gc3118aa")
-
-// resolvers += "Era7 maven snapshots" at "https://s3-eu-west-1.amazonaws.com/snapshots.era7.com"
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-9-g5239d7c-SNAPSHOT")
+// addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-8-gc3118aa")
 
 // addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.1.2-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2+")
-// addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-8-gc3118aa")
+// addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2+")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC2-10-gf28fae6")
 
 // addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.1.2-SNAPSHOT")

--- a/src/main/scala/GithubRelease.scala
+++ b/src/main/scala/GithubRelease.scala
@@ -89,7 +89,7 @@ case object GithubRelease {
 
       val tagNames = repo.listTags.asSet.map(_.getName)
       if (! tagNames.contains(tagName)) {
-        sys.error("Remote repository doesn't have [${tagName}] tag. You need to push it first.")
+        sys.error(s"Remote repository doesn't have [${tagName}] tag. You need to push it first.")
       }
 
       def releaseExists: Boolean =
@@ -97,7 +97,7 @@ case object GithubRelease {
 
       // if (!draft.value && releaseExists) {
       if (releaseExists) {
-        sys.error("There is already a Github release based on [${tagName}] tag. You cannot release it twice.")
+        sys.error(s"There is already a Github release based on [${tagName}] tag. You cannot release it twice.")
         // TODO: ask to overwrite (+ report if it is a draft)
       }
 

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -14,7 +14,7 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
 
   // Default settings
   override lazy val projectSettings = Seq[Setting[_]](
-    ghreleaseNotes     := baseDirectory.value / "notes" / (version.value+".markdown"),
+    ghreleaseNotes     := { tagName => IO.read(baseDirectory.value / "notes" / s"${tagName}.markdown") },
     ghreleaseRepoOrg   := organization.value,
     ghreleaseRepoName  := name.value,
     ghreleaseTitle     := { tagName => s"${name.value} ${tagName}" },

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -46,6 +46,8 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
       )
     }
 
-    (Space ~> suggestions.getOrElse(StringBasic)) ?? version.value
+    val fallback = s"v${version.value}"
+
+    (Space ~> suggestions.getOrElse(StringBasic)) ?? fallback
   }
 }

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -21,9 +21,7 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
     ghreleaseNotes     := baseDirectory.value / "notes" / (version.value+".markdown"),
     ghreleaseRepoOrg   := organization.value,
     ghreleaseRepoName  := name.value,
-    ghreleaseTag       := "v"+version.value,
-    ghreleaseTitle     := name.value +" "+ ghreleaseTag.value,
-    ghreleaseCommitish := "",
+    ghreleaseTitle     := { tagName => s"${name.value} ${tagName}" },
     // According to the Semantic Versioning Specification (rule 9)
     // a version containing a hyphen is a pre-release version
     ghreleaseIsPrerelease := { _.matches(""".*-.*""") },

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -24,54 +24,11 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
     ghreleaseTitle     := { tagName => s"${name.value} ${tagName}" },
     // According to the Semantic Versioning Specification (rule 9)
     // a version containing a hyphen is a pre-release version
-    ghreleaseIsPrerelease := { _.matches(""".*-.*""") },
-
-    ghreleaseMediaTypesMap := {
-      val typeMap = new javax.activation.MimetypesFileTypeMap()
-      // NOTE: github doesn't know about application/java-archive type (see https://developer.github.com/v3/repos/releases/#input-2)
-      typeMap.addMimeTypes("application/zip jar zip")
-      // and .pom is unlikely to be in the system's default MIME types map
-      typeMap.addMimeTypes("application/xml pom xml")
-
-      typeMap.getContentType
-    },
-
-    ghreleaseAssets := packagedArtifacts.value.values.toSeq,
-
-    ghreleaseGetCredentials := {
-      val log = streams.value.log
-      val conf = file(System.getProperty("user.home")) / ".github"
-      while (!conf.exists || !GitHub.connect.isCredentialValid) {
-        log.warn("Your github credentials for sbt-github-release plugin are not set yet")
-        SimpleReader.readLine("Go to https://github.com/settings/applications \ncreate a new token and paste it here: ") match {
-          case Some(token) => {
-            try {
-              val gh = GitHub.connectUsingOAuth(token)
-              if (gh.isCredentialValid) {
-                IO.writeLines(conf, Seq("oauth = " + token))//, append = true)
-                log.info("Wrote OAuth token to " + conf)
-              }
-            } catch {
-              case e: Exception => log.error(e.toString)
-            }
-          }
-          case _ => sys.error("If you want to use sbt-github-release plugin, you should set credentials correctly")
-        }
-      }
-      log.info("Github credentials are ok")
-      GitHub.connect
-    },
-
-    ghreleaseGetRepo := {
-      val log = streams.value.log
-      val github = ghreleaseGetCredentials.value
-      val repo = s"${ghreleaseRepoOrg.value}/${ghreleaseRepoName.value}"
-
-      val repository = Try { github.getRepository(repo) } getOrElse {
-        sys.error(s"Repository ${repo} doesn't exist or is not accessible.")
-      }
-      repository
-    },
+    ghreleaseIsPrerelease   := { _.matches(""".*-.*""") },
+    ghreleaseMediaTypesMap  := defs.ghreleaseMediaTypesMap,
+    ghreleaseAssets         := packagedArtifacts.value.values.toSeq,
+    ghreleaseGetCredentials := defs.ghreleaseGetCredentials.value,
+    ghreleaseGetRepo        := defs.ghreleaseGetRepo.value,
 
     ghreleaseGetReleaseBuilder := Def.inputTaskDyn {
       defs.ghreleaseGetReleaseBuilder(tagNameArg.parsed)

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -14,7 +14,10 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
 
   // Default settings
   override lazy val projectSettings = Seq[Setting[_]](
-    ghreleaseNotes     := { tagName => IO.read(baseDirectory.value / "notes" / s"${tagName}.markdown") },
+    ghreleaseNotes     := { tagName =>
+      val ver = tagName.stripPrefix("v")
+      IO.read(baseDirectory.value / "notes" / s"${ver}.markdown")
+    },
     ghreleaseRepoOrg   := organization.value,
     ghreleaseRepoName  := name.value,
     ghreleaseTitle     := { tagName => s"${name.value} ${tagName}" },

--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -9,6 +9,7 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
 
   // This plugin will load automatically
   override def trigger = allRequirements
+  override def requires = empty
 
   val autoImport = GithubRelease.keys
 


### PR DESCRIPTION
Make `releaseOnGithub` an input task and provide its implementation as `Def.task` for non-interactive usage.

This will help to make releases of old tags without resetting version setting.