### PR TITLE
Fix requires in the plugin

### DIFF
--- a/src/main/scala/SbtGithubReleasePlugin.scala
+++ b/src/main/scala/SbtGithubReleasePlugin.scala
@@ -8,7 +8,7 @@ case object SbtGithubReleasePlugin extends AutoPlugin {
 
   // This plugin will load automatically
   override def trigger = allRequirements
-  override def requires = empty
+  override def requires = sbt.plugins.IvyPlugin
 
   val autoImport = GithubRelease.keys
 


### PR DESCRIPTION
The requires definition should always, at the very least, point to `CorePlugin`, because a project may want to disable sbt plugin on its own.

This commit sets it to `IvyPlugin` because it seems the right abstraction: if you cannot update the project, you probably cannot release it.