### PR TITLE
Set default GithubRelease.repoName from git config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,10 @@ The main task is `githubRelease`, it creates the release and publishes the asset
 
 You can find their defaults in the plugin [code](src/main/scala/SbtGithubReleasePlugin.scala).
 
+#### Autodetect repository organization and name
+
+By default, this plugin will try to auto-detect settings for `ghreleaseRepoOrg` and `ghreleaseRepoName` based on git remote with name `origin`. If such remote not exist then plugin will fallback to sbt organization/name. If you would like to avoid auto-detect behavior you should set `ghreleaseRepoOrg` and `ghreleaseRepoName` explicitly.
+
 #### Assets
 
 You can set which files to attach to the release using the `ghreleaseAssets` task (of `Seq[File]` type). By default it refers to the `packagedArtifacts` task.

--- a/src/main/scala/GithubRelease.scala
+++ b/src/main/scala/GithubRelease.scala
@@ -12,6 +12,8 @@ case object GithubRelease {
   type DefTask[X] = Def.Initialize[Task[X]]
   type DefSetting[X] = Def.Initialize[Setting[X]]
 
+  case class Origin(organization: String, name: String)
+
   case object keys {
     type TagName = String
 
@@ -22,6 +24,7 @@ case object GithubRelease {
     lazy val ghreleaseTitle         = settingKey[TagName => String]("The title of the release")
     lazy val ghreleaseIsPrerelease  = settingKey[TagName => Boolean]("A function to determine release as a prerelease based on the tag name")
     lazy val ghreleaseGithubToken   = settingKey[Option[String]]("Credentials for accessing the GitHub API")
+    lazy val ghreleaseGithubOrigin  = settingKey[Option[Origin]]("GitHub origin")
 
     lazy val ghreleaseAssets  = taskKey[Seq[File]]("The artifact files to upload")
     lazy val ghreleaseGetRepo = taskKey[GHRepository]("Checks repo existence and returns it if it's fine")


### PR DESCRIPTION
Hi,
I see only 'ghreleaseRepoOrg' and 'ghreleaseRepoName' and no `GithubRelease.repoName`.  So, I have preset these values based on config if it possible. If they not availably then project org/name used as previously. 
Please review and correct me if I am wrong in understanding. Thanks!