### PR TITLE
Using standalone javax.activation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,4 +10,4 @@ sbtVersion   := "1.3.8"
 //bucketSuffix := "era7.com"
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.92"
-libraryDependencies += "jakarta.activation" % "jakarta.activation-api" % "1.2.2"
+libraryDependencies += "com.sun.activation" % "jakarta.activation" % "1.2.2"

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,10 @@ name         := "sbt-github-release"
 organization := "ohnosequences"
 description  := "sbt plugin using github releases api"
 
-scalaVersion := "2.12.7"
-sbtVersion   := "1.2.6"
+scalaVersion := "2.12.10"
+sbtVersion   := "1.3.8"
 
 //bucketSuffix := "era7.com"
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.92"
+libraryDependencies += "jakarta.activation" % "jakarta.activation-api" % "1.2.2"

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,10 @@ description  := "sbt plugin using github releases api"
 scalaVersion := "2.12.4"
 sbtVersion   := "1.0.4"
 
-bucketSuffix := "era7.com"
+//bucketSuffix := "era7.com"
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.92"
+libraryDependencies += "com.sun.activation" % "javax.activation" % "1.2.0"
 
 bintrayReleaseOnPublish := !isSnapshot.value
 bintrayOrganization     := Some(organization.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.0
+sbt.version = 1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 resolvers += Resolver.jcenterRepo
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.9.0-4-g2ca7993")
+//addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.9.0-4-g2ca7993")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
 
 // dependencyOverrides += "ohnosequences" % "sbt-github-release" % "0.6.0-16-ge8e5ec5"

--- a/src/main/scala/GithubRelease.scala
+++ b/src/main/scala/GithubRelease.scala
@@ -47,7 +47,6 @@ case object GithubRelease {
       typeMap.addMimeTypes("application/zip jar zip")
       // and .pom is unlikely to be in the system's default MIME types map
       typeMap.addMimeTypes("application/xml pom xml")
-
       typeMap.getContentType
     }
 


### PR DESCRIPTION
This PR replaces built-in `javax.activation` module with standalone JAF (since the former is deprecated in Java 9 and 10 and can be only enabled with a command-line argument (see #28), and in Java 11 does not work at all). 
So, #28 seems to be fixed here.
_Note: the `nice-sbt-settings` dependency is temporarily disabled because it in turn depends on the older version of `sbt-github-release`, and the plugin won't build for the very same reason. To fix this, you need to accept this PR first, then set the version requirement in `nice-sbt-settings`._