### PR TITLE
Release v0.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,9 @@ name         := "sbt-github-release"
 organization := "ohnosequences"
 description  := "sbt plugin using github releases api"
 
-scalaVersion := "2.12.4"
-sbtVersion   := "1.0.4"
+scalaVersion := "2.12.6"
+sbtVersion   := "1.2.6"
 
 bucketSuffix := "era7.com"
 
-libraryDependencies += "org.kohsuke" % "github-api" % "1.92"
-
-bintrayReleaseOnPublish := !isSnapshot.value
-bintrayOrganization     := Some(organization.value)
-bintrayPackageLabels    := Seq("sbt", "sbt-plugin", "github", "releases", "publish")
-
-publishMavenStyle := false
-publishTo := (publishTo in bintray).value
+libraryDependencies += "org.kohsuke" % "github-api" % "1.94"

--- a/notes/0.7.1.markdown
+++ b/notes/0.7.1.markdown
@@ -1,0 +1,1 @@
+Includes patch #27: Takes github repo name from git config instead of build.sbt  (by @vshalts)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 resolvers += Resolver.jcenterRepo
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.9.0-4-g2ca7993")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.10.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
 
 // dependencyOverrides += "ohnosequences" % "sbt-github-release" % "0.6.0-16-ge8e5ec5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
-resolvers += Resolver.jcenterRepo
+//resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.10.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
+//addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
 
 // dependencyOverrides += "ohnosequences" % "sbt-github-release" % "0.6.0-16-ge8e5ec5"


### PR DESCRIPTION
This PR releases a new version #27, updating the notes, and bumping dependencies. Also, publishing of the artifacts to `bintray` has been removed.